### PR TITLE
Fix `data.aws_iam_role.existing` count logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,28 @@
 locals {
-  module_and_iam_role_enabled = module.this.enabled && var.iam_role_enabled
-  module_and_plan_enabled     = module.this.enabled && var.plan_enabled
+  enabled          = module.this.enabled
+  iam_role_enabled = local.enabled && var.iam_role_enabled
+  plan_enabled     = local.enabled && var.plan_enabled
+  vault_enabled    = local.enabled && var.vault_enabled
 }
 
 module "label_backup_role" {
   source     = "cloudposse/label/null"
   version    = "0.24.1"
-  enabled    = module.this.enabled
+  enabled    = local.enabled
   attributes = ["backup"]
 
   context = module.this.context
 }
 
 resource "aws_backup_vault" "default" {
-  count       = module.this.enabled && var.vault_enabled ? 1 : 0
+  count       = local.vault_enabled ? 1 : 0
   name        = module.this.id
   kms_key_arn = var.kms_key_arn
   tags        = module.this.tags
 }
 
 resource "aws_backup_plan" "default" {
-  count = module.this.enabled && var.plan_enabled ? 1 : 0
+  count = local.plan_enabled ? 1 : 0
   name  = var.plan_name_suffix == null ? module.this.id : format("%s_%s", module.this.id, var.plan_name_suffix)
 
   rule {
@@ -59,7 +61,7 @@ resource "aws_backup_plan" "default" {
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = module.this.enabled ? 1 : 0
+  count = local.iam_role_enabled ? 1 : 0
 
   statement {
     effect  = "Allow"
@@ -73,25 +75,25 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = local.module_and_iam_role_enabled ? 1 : 0
+  count              = local.iam_role_enabled ? 1 : 0
   name               = var.target_iam_role_name == null ? module.label_backup_role.id : var.target_iam_role_name
   assume_role_policy = join("", data.aws_iam_policy_document.assume_role.*.json)
   tags               = module.label_backup_role.tags
 }
 
 data "aws_iam_role" "existing" {
-  count = local.module_and_iam_role_enabled ? 0 : 1
+  count = local.enabled && var.iam_role_enabled == false ? 1 : 0
   name  = module.label_backup_role.id
 }
 
 resource "aws_iam_role_policy_attachment" "default" {
-  count      = local.module_and_iam_role_enabled ? 1 : 0
+  count      = local.iam_role_enabled ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_backup_selection" "default" {
-  count        = local.module_and_plan_enabled ? 1 : 0
+  count        = local.plan_enabled ? 1 : 0
   name         = module.this.id
   iam_role_arn = join("", var.iam_role_enabled ? aws_iam_role.default.*.arn : data.aws_iam_role.existing.*.arn)
   plan_id      = join("", aws_backup_plan.default.*.id)


### PR DESCRIPTION
## what
* Fix `data.aws_iam_role.existing` count logic.

## why
* When `enabled = false`, it tries to find the existing iam role

## references
N/A

