### PR TITLE
Remove `backup_vault_recovery_points` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ Available targets:
 | <a name="output_backup_selection_id"></a> [backup\_selection\_id](#output\_backup\_selection\_id) | Backup Selection ID |
 | <a name="output_backup_vault_arn"></a> [backup\_vault\_arn](#output\_backup\_vault\_arn) | Backup Vault ARN |
 | <a name="output_backup_vault_id"></a> [backup\_vault\_id](#output\_backup\_vault\_id) | Backup Vault ID |
-| <a name="output_backup_vault_recovery_points"></a> [backup\_vault\_recovery\_points](#output\_backup\_vault\_recovery\_points) | Backup Vault recovery points |
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -79,5 +79,4 @@
 | <a name="output_backup_selection_id"></a> [backup\_selection\_id](#output\_backup\_selection\_id) | Backup Selection ID |
 | <a name="output_backup_vault_arn"></a> [backup\_vault\_arn](#output\_backup\_vault\_arn) | Backup Vault ARN |
 | <a name="output_backup_vault_id"></a> [backup\_vault\_id](#output\_backup\_vault\_id) | Backup Vault ID |
-| <a name="output_backup_vault_recovery_points"></a> [backup\_vault\_recovery\_points](#output\_backup\_vault\_recovery\_points) | Backup Vault recovery points |
 <!-- markdownlint-restore -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -60,11 +60,6 @@ output "backup_vault_arn" {
   description = "Backup Vault ARN"
 }
 
-output "backup_vault_recovery_points" {
-  value       = module.backup.backup_vault_recovery_points
-  description = "Backup Vault recovery points"
-}
-
 output "backup_plan_arn" {
   value       = module.backup.backup_plan_arn
   description = "Backup Plan ARN"

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,11 +8,6 @@ output "backup_vault_arn" {
   description = "Backup Vault ARN"
 }
 
-output "backup_vault_recovery_points" {
-  value       = join("", aws_backup_vault.default.*.recovery_points)
-  description = "Backup Vault recovery points"
-}
-
 output "backup_plan_arn" {
   value       = join("", aws_backup_plan.default.*.arn)
   description = "Backup Plan ARN"


### PR DESCRIPTION

## what
* removed `backup_vault_recovery_points` as an output, as it is not affected by resource changes

## why
* Noisy output with little use
