### PR TITLE
Allow `target_iam_role_name` in existing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ resource "aws_iam_role" "default" {
 
 data "aws_iam_role" "existing" {
   count = local.enabled && var.iam_role_enabled == false ? 1 : 0
-  name  = module.label_backup_role.id
+  name  = var.target_iam_role_name == null ? module.label_backup_role.id : var.target_iam_role_name
 }
 
 resource "aws_iam_role_policy_attachment" "default" {


### PR DESCRIPTION
## what
* Allow `target_iam_role_name` in existing

## why
* I want to change the `name` variable and reuse an existing iam role that was created when I did not overwrite the `name` variable.

## references
N/A

