### PR TITLE
Add extra managed policy dedicated to S3 backups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,12 @@ resource "aws_iam_role_policy_attachment" "default" {
   role       = join("", aws_iam_role.default.*.name)
 }
 
+resource "aws_iam_role_policy_attachment" "s3" {
+  count      = local.iam_role_enabled ? 1 : 0
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
+  role       = join("", aws_iam_role.default.*.name)
+}
+
 resource "aws_backup_selection" "default" {
   count         = local.plan_enabled ? 1 : 0
   name          = module.this.id


### PR DESCRIPTION
## what

AWS Backup for S3 buckets has reached GA recently (Feb 18 2022).

It seems AWS created a separate dedicated managed policy with the
permissions required to backup S3.

## why

I am not sure if my fix is the correct way to address this, but for some reason that I ignore the managed policy of the backup service-linked role does not include the necessary S3 permissions and my backup fail (note that I did enable S3 for Backup in the Backup options via the Web Console).

## references
- https://aws.amazon.com/about-aws/whats-new/2022/02/general-availability-aws-backup-amazon-s3/
- https://docs.aws.amazon.com/aws-backup/latest/devguide/security-iam-awsmanpol.html#aws-managed-policies
