### PR TITLE
FIx type compatibility issue when overriding rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ locals {
       }
     }
   }]
-  compatible_rules = length(var.rules) == 0 ? local.single_rule : [{ for k, v in local.single_rule[0] : k => v }]
+  compatible_rules = length(var.rules) == 0 ? local.single_rule : tolist([{ for k, v in local.single_rule[0] : k => v }])
 }
 
 data "aws_partition" "current" {}


### PR DESCRIPTION
## what
- Add a `tolist()`

## why
- Should fix the following:

    ```hcl
    Error: Inconsistent conditional result types
    │ 
    │   on .terraform/modules/backup/main.tf line 62, in resource "aws_backup_plan" "default":
    │   62:     for_each = length(var.rules) > 0 ? var.rules : local.compatible_rules
    │     ├────────────────
    │     │ local.compatible_rules is tuple with 1 element
    │     │ var.rules is list of object with 1 element
    │ 
    │ The true and false result expressions must have consistent types. The given expressions are list
    │ of object and tuple, respectively.
    ```

## references
- Should close https://github.com/cloudposse/terraform-aws-backup/issues/46
