### PR TITLE
fix: remove additional not null check

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
@@ -465,7 +465,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-backup&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-backup&utm_content=website
@@ -496,3 +496,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-backup
   [share_email]: mailto:?subject=terraform-aws-backup&body=https://github.com/cloudposse/terraform-aws-backup
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-backup?pixel&cs=github&cm=readme&an=terraform-aws-backup
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,7 @@ resource "aws_backup_plan" "default" {
           destination_vault_arn = lookup(rule.value.copy_action, "destination_vault_arn", null)
 
           dynamic "lifecycle" {
-            for_each = lookup(rule.value.copy_action, "lifecycle", null) != null != null ? [true] : []
+            for_each = lookup(rule.value.copy_action, "lifecycle", null) != null ? [true] : []
 
             content {
               cold_storage_after = lookup(rule.value.copy_action.lifecycle, "cold_storage_after", null)


### PR DESCRIPTION
## what
* With the typo in place the dynamic incorrectly evaluates a missing copy_action.lifecycle element as present
* This causes an unsupported attribute error

## why
* Allow copy_action elements in rules without lifecycle defined to be used

## references
* N/A

