### PR TITLE
Change advanced_backup_setting.backup_options map(string)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -48,7 +48,7 @@ variable "rules" {
 
 variable "advanced_backup_setting" {
   type = object({
-    backup_options = string
+    backup_options = map(string)
     resource_type  = string
   })
   description = "An object that specifies backup options for each resource type"


### PR DESCRIPTION
## what

- Change the variable `advanced_backup_setting.backup_options` from type `string` to type `map(string)`.

## why

If the `advanced_backup_setting.backup_options` variable is a string, this results in an error when planning or applying:

```
16:21:12.722 ERROR  terraform invocation failed in /tmp/terragrunt-cache/-FDnhxSQgd3gy3AJn3jI-TkIT9c/DzZH2oKvEUO4zTXgeTgdoazRmVw
16:21:12.722 ERROR  error occurred:

* Failed to execute "terraform plan" in /tmp/terragrunt-cache/-FDnhxSQgd3gy3AJn3jI-TkIT9c/DzZH2oKvEUO4zTXgeTgdoazRmVw
  ╷
  │ Error: Incorrect attribute value type
  │ 
  │   on main.tf line 93, in resource "aws_backup_plan" "default":
  │   93:       backup_options = var.advanced_backup_setting.backup_options
  │     ├────────────────
  │     │ var.advanced_backup_setting.backup_options is "{ WindowsVSS = \"enabled\" }"
  │ 
  │ Inappropriate value for attribute "backup_options": map of string required.
  ╵
  
  exit status 1
```

The provider helpfully suggests: `Inappropriate value for attribute "backup_options": map of string required.`. Making this change results in a successful plan.

## references

The Example Usage demonstrates the use of a map for this parameter:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_plan#example-usage
