### PR TITLE
feat: add "role" to naming null-label for the role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "label_backup_role" {
   source     = "cloudposse/label/null"
   version    = "0.25.0"
   enabled    = local.enabled
-  attributes = ["backup"]
+  attributes = ["backup", "role"]
 
   context = module.this.context
 }


### PR DESCRIPTION
I believe it looks funky when the default role created is ${module.this.id}-backup. It doesn't make sense that the only distinction of `module "label_backup_role"` is just an additional "backup" attribute. 

Using the `examples/complete`, it would generate a role of `eg-testing-backup-backup`. Looks weird! I would even change the existing attribute to be "role" only...

This is going to change the IAM role names so if some dependencies are referencing the ARN of the IAM role, it would break... Should this be a breaking change? 